### PR TITLE
Add tables/columns for traffic stats and begin recording them

### DIFF
--- a/src/data/traffic_data.py
+++ b/src/data/traffic_data.py
@@ -1,0 +1,101 @@
+import datetime
+from typing import Optional
+
+from sqlalchemy.sql import text
+
+from data.base_data import BaseModel, BaseData
+
+
+class TrafficMonthlyModel(BaseModel):
+    """
+    Note: date is the first day of the month.
+    """
+
+    _table = "traffic_monthly"
+    _pk_field = "id"
+    _columns = ["id", "date", "unique_pageviews", "total_pageviews"]
+
+
+class TrafficDailyModel(BaseModel):
+    _table = "traffic_daily"
+    _pk_field = "id"
+    _columns = ["id", "date", "unique_pageviews", "total_pageviews", "subscribers"]
+
+
+class TrafficData(BaseData):
+    def get_monthly_traffic_by_range(
+        self, start_date: datetime.date, end_date: datetime.date
+    ) -> list[TrafficMonthlyModel]:
+        """Gets the monthly traffic between the dates specified (inclusive)."""
+
+        start_date_str = start_date.isoformat()
+        end_date_str = end_date.isoformat()
+
+        sql = text(
+            """
+        SELECT * FROM traffic_monthly
+        WHERE date >= :start_date and date <= :end_date;
+        """
+        )
+
+        result_rows = self.execute(sql, start_date=start_date_str, end_date=end_date_str)
+        if not result_rows:
+            return []
+
+        return [TrafficMonthlyModel(row) for row in result_rows]
+
+    def get_daily_traffic_by_range(self, start_date: datetime.date, end_date: datetime.date) -> list[TrafficDailyModel]:
+        """Gets the daily traffic between the dates specified (inclusive)."""
+
+        start_date_str = start_date.isoformat()
+        end_date_str = end_date.isoformat()
+
+        sql = text(
+            """
+        SELECT * FROM traffic_daily
+        WHERE date >= :start_date and date <= :end_date;
+        """
+        )
+
+        result_rows = self.execute(sql, start_date=start_date_str, end_date=end_date_str)
+        if not result_rows:
+            return []
+
+        return [TrafficDailyModel(row) for row in result_rows]
+
+    def get_monthly_traffic_by_datetime(self, target_date: datetime.date) -> Optional[TrafficMonthlyModel]:
+        """Gets the monthly traffic for the date, rounding down from the provided target_date
+        to the start of the month."""
+
+        target_date_str = target_date.replace(day=1).isoformat()
+
+        sql = text(
+            """
+        SELECT * FROM traffic_monthly
+        WHERE date = :date;
+        """
+        )
+
+        result_rows = self.execute(sql, date=target_date_str)
+        if not result_rows:
+            return None
+
+        return TrafficMonthlyModel(result_rows[0])
+
+    def get_daily_traffic_by_datetime(self, target_date: datetime.date) -> Optional[TrafficDailyModel]:
+        """Gets the daily traffic for the date."""
+
+        target_date_str = target_date.isoformat()
+
+        sql = text(
+            """
+        SELECT * FROM traffic_daily
+        WHERE date = :date;
+        """
+        )
+
+        result_rows = self.execute(sql, date=target_date_str)
+        if not result_rows:
+            return None
+
+        return TrafficDailyModel(result_rows[0])

--- a/src/data/traffic_data.py
+++ b/src/data/traffic_data.py
@@ -19,7 +19,7 @@ class TrafficMonthlyModel(BaseModel):
 class TrafficDailyModel(BaseModel):
     _table = "traffic_daily"
     _pk_field = "id"
-    _columns = ["id", "date", "unique_pageviews", "total_pageviews", "subscribers"]
+    _columns = ["id", "date", "unique_pageviews", "total_pageviews", "net_subscribers"]
 
 
 class TrafficData(BaseData):

--- a/src/services/snapshot_service.py
+++ b/src/services/snapshot_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+import datetime
 from typing import Optional
 
 from praw.models.reddit.submission import Submission
@@ -11,7 +11,13 @@ from utils.logger import logger
 _snapshot_data = SnapshotData()
 
 
-def add_snapshot(current_datetime: datetime, subscribers: int) -> SnapshotModel:
+def get_snapshot_by_datetime(target_datetime: datetime.datetime) -> SnapshotModel:
+    """Get the specified snapshot from the database."""
+
+    return _snapshot_data.get_snapshot_by_datetime(target_datetime)
+
+
+def add_snapshot(current_datetime: datetime.datetime, subscribers: int) -> SnapshotModel:
     """Adds a new snapshot to the database."""
 
     snapshot = SnapshotModel()
@@ -21,6 +27,34 @@ def add_snapshot(current_datetime: datetime, subscribers: int) -> SnapshotModel:
 
     saved_snapshot = _snapshot_data.insert(snapshot)
     return saved_snapshot
+
+
+def update_hourly_traffic(traffic_data: list[list[int]]):
+    """
+    Expected format for each traffic_data list item should match the "hour" value of /about/traffic endpoint:
+        [timestamp (start of hour), unique_pageviews, total_pageviews]
+    """
+
+    oldest_date = datetime.date.fromtimestamp(traffic_data[-1][0])
+    today = datetime.datetime.now(datetime.timezone.utc).date()
+    current_snapshot_rows = _snapshot_data.get_snapshots_by_date_range(oldest_date, today)
+    current_snapshots_by_hour = {model.get_datetime(): model for model in current_snapshot_rows}
+
+    for row in traffic_data:
+        record_datetime = datetime.datetime.fromtimestamp(row[0], tz=datetime.timezone.utc)
+        unique_pageviews, total_pageviews = row[1:3]
+
+        # If, *somehow*, this date/hour doesn't exist in the database, skip for now (no subscriber count available).
+        if record_datetime not in current_snapshots_by_hour:
+            continue
+
+        # Otherwise see if the data needs updating. Reddit's inconsistent with when they add data so...
+        current_snapshot = current_snapshots_by_hour[record_datetime]
+        if unique_pageviews != 0:
+            current_snapshot.unique_pageviews = unique_pageviews
+        if total_pageviews != 0:
+            current_snapshot.total_pageviews = total_pageviews
+        _snapshot_data.update(current_snapshot)
 
 
 def add_frontpage_post(reddit_post: Submission, snapshot: SnapshotModel, rank: int) -> SnapshotFrontpageModel:
@@ -46,7 +80,7 @@ def add_frontpage_post(reddit_post: Submission, snapshot: SnapshotModel, rank: i
     return saved_frontpage_model
 
 
-def get_frontpage_rank(post_id: int, target_datetime: datetime, min_rank: int = 25) -> Optional[int]:
+def get_frontpage_rank(post_id: int, target_datetime: datetime.datetime, min_rank: int = 25) -> Optional[int]:
     """Gets the ranking of the post at the specified target_datetime, None if not ranked at that time.
     Will ignore anything below min_rank."""
 

--- a/src/services/traffic_service.py
+++ b/src/services/traffic_service.py
@@ -15,7 +15,7 @@ def add_daily_traffic(
     traffic.date = target_date
     traffic.unique_pageviews = unique_pageviews
     traffic.total_pageviews = total_pageviews
-    traffic.subscribers = subscribers
+    traffic.net_subscribers = subscribers
 
     saved_traffic = _traffic_data.insert(traffic)
     return saved_traffic
@@ -88,5 +88,5 @@ def update_daily_traffic(traffic_data: list[list[int]]):
             current_traffic.unique_pageviews = unique_pageviews
         if total_pageviews != 0:
             current_traffic.total_pageviews = total_pageviews
-        current_traffic.subscribers = subscribers
+        current_traffic.net_subscribers = subscribers
         _traffic_data.update(current_traffic)

--- a/src/services/traffic_service.py
+++ b/src/services/traffic_service.py
@@ -1,0 +1,92 @@
+import datetime
+
+from data.traffic_data import TrafficData, TrafficMonthlyModel, TrafficDailyModel
+
+
+_traffic_data = TrafficData()
+
+
+def add_daily_traffic(
+    target_date: datetime.date, unique_pageviews: int, total_pageviews: int, subscribers: int
+) -> TrafficDailyModel:
+    """Adds a new row of daily traffic data to the database."""
+
+    traffic = TrafficDailyModel()
+    traffic.date = target_date
+    traffic.unique_pageviews = unique_pageviews
+    traffic.total_pageviews = total_pageviews
+    traffic.subscribers = subscribers
+
+    saved_traffic = _traffic_data.insert(traffic)
+    return saved_traffic
+
+
+def add_monthly_traffic(target_date: datetime.date, unique_pageviews: int, total_pageviews: int) -> TrafficMonthlyModel:
+    """Adds a new row of monthly traffic data to the database."""
+
+    traffic = TrafficMonthlyModel()
+    traffic.date = target_date
+    traffic.unique_pageviews = unique_pageviews
+    traffic.total_pageviews = total_pageviews
+
+    saved_traffic = _traffic_data.insert(traffic)
+    return saved_traffic
+
+
+def update_monthly_traffic(traffic_data: list[list[int]]):
+    """
+    Expected format for each traffic_data list item should match the "month" value of /about/traffic endpoint:
+        [timestamp (start of month), unique_pageviews, total_pageviews]
+    """
+
+    oldest_date = datetime.date.fromtimestamp(traffic_data[-1][0])
+    today = datetime.datetime.now(datetime.timezone.utc).date()
+    current_traffic_rows = _traffic_data.get_monthly_traffic_by_range(oldest_date, today)
+    current_traffic_by_date = {model.date: model for model in current_traffic_rows}
+
+    for row in traffic_data:
+        date = datetime.date.fromtimestamp(row[0])
+        unique_pageviews, total_pageviews = row[1:3]
+
+        # New entry, date not currently in database.
+        if date not in current_traffic_by_date:
+            add_monthly_traffic(date, unique_pageviews, total_pageviews)
+            continue
+
+        # Otherwise see if the data needs updating for some reason.
+        current_traffic = current_traffic_by_date[date]
+        if unique_pageviews != 0:
+            current_traffic.unique_pageviews = unique_pageviews
+        if total_pageviews != 0:
+            current_traffic.total_pageviews = total_pageviews
+        _traffic_data.update(current_traffic)
+
+
+def update_daily_traffic(traffic_data: list[list[int]]):
+    """
+    Expected format for each traffic_data list item should match "day" value of the /about/traffic endpoint:
+        [timestamp (start of day), unique_pageviews, total_pageviews, subscribers]
+    """
+
+    oldest_date = datetime.date.fromtimestamp(traffic_data[-1][0])
+    today = datetime.datetime.now(datetime.timezone.utc).date()
+    current_traffic_rows = _traffic_data.get_daily_traffic_by_range(oldest_date, today)
+    current_traffic_by_date = {model.date: model for model in current_traffic_rows}
+
+    for row in traffic_data:
+        date = datetime.date.fromtimestamp(row[0])
+        unique_pageviews, total_pageviews, subscribers = row[1:4]
+
+        # New entry, date not currently in database.
+        if date not in current_traffic_by_date:
+            add_daily_traffic(date, unique_pageviews, total_pageviews, subscribers)
+            continue
+
+        # Otherwise see if the data needs updating for some reason.
+        current_traffic = current_traffic_by_date[date]
+        if unique_pageviews != 0:
+            current_traffic.unique_pageviews = unique_pageviews
+        if total_pageviews != 0:
+            current_traffic.total_pageviews = total_pageviews
+        current_traffic.subscribers = subscribers
+        _traffic_data.update(current_traffic)

--- a/tools/db_migration/env.py
+++ b/tools/db_migration/env.py
@@ -27,7 +27,7 @@ target_metadata = None
 # ... etc.
 db_user_str = f'{os.environ.get("DB_USER", "postgres")}:{os.environ.get("DB_PASSWORD", "postgres")}'
 db_host_str = f'{os.environ.get("DB_HOST", "modbot-db")}:{os.environ.get("DB_POST", 5432)}'
-db_connection_str = f'postgres+psycopg2://{db_user_str}@{db_host_str}/{os.environ.get("DB_NAME", "postgres")}'
+db_connection_str = f'postgresql+psycopg2://{db_user_str}@{db_host_str}/{os.environ.get("DB_NAME", "postgres")}'
 config.set_main_option("sqlalchemy.url", db_connection_str)
 
 

--- a/tools/db_migration/versions/20211109T022238Z_add_traffic_tables_ef9e7017d686.py
+++ b/tools/db_migration/versions/20211109T022238Z_add_traffic_tables_ef9e7017d686.py
@@ -1,0 +1,51 @@
+"""Add traffic tables
+
+Revision ID: ef9e7017d686
+Revises: a2be73588d9d
+Create Date: 2021-11-09 02:22:38.435818+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ef9e7017d686"
+down_revision = "a2be73588d9d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+    CREATE TABLE IF NOT EXISTS traffic_monthly (
+        id serial primary key,
+        date date not null UNIQUE,
+        unique_pageviews int,
+        total_pageviews int
+    );
+    CREATE TABLE IF NOT EXISTS traffic_daily (
+        id serial primary key,
+        date date not null UNIQUE,
+        unique_pageviews int,
+        total_pageviews int,
+        net_subscribers int
+    );
+
+    ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS unique_pageviews int;
+    ALTER TABLE snapshots ADD COLUMN IF NOT EXISTS total_pageviews int;
+    """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+    ALTER TABLE snapshots DROP COLUMN IF EXISTS total_comments;
+    ALTER TABLE snapshots DROP COLUMN IF EXISTS total_posts;
+    ALTER TABLE snapshots DROP COLUMN IF EXISTS total_pageviews;
+    ALTER TABLE snapshots DROP COLUMN IF EXISTS unique_pageviews;
+
+    DROP TABLE IF EXISTS traffic_daily;
+    DROP TABLE IF EXISTS traffic_monthly;
+    """
+    )

--- a/tools/db_migration/versions/20211109T022238Z_add_traffic_tables_ef9e7017d686.py
+++ b/tools/db_migration/versions/20211109T022238Z_add_traffic_tables_ef9e7017d686.py
@@ -40,8 +40,6 @@ def upgrade():
 def downgrade():
     op.execute(
         """
-    ALTER TABLE snapshots DROP COLUMN IF EXISTS total_comments;
-    ALTER TABLE snapshots DROP COLUMN IF EXISTS total_posts;
     ALTER TABLE snapshots DROP COLUMN IF EXISTS total_pageviews;
     ALTER TABLE snapshots DROP COLUMN IF EXISTS unique_pageviews;
 


### PR DESCRIPTION
Whenever the hourly snapshot is taken, also save any available traffic stats from the `/about/traffic` endpoint. Implements #5.