### PR TITLE
make sub mentions filtering case insensitive

### DIFF
--- a/src/feeds/sub_mentions.py
+++ b/src/feeds/sub_mentions.py
@@ -26,7 +26,7 @@ def check_inbox(reddit):
         # Check to see that it's actually a reference to /r/anime and not something else.
         # Negative lookahead is to catch weird formatting from redesign handling underscores, e.g. r/anime\_irl
         # or people using a hyphen instead of underscore like r/anime-titties
-        if not re.search(r"\br/anime\b(?!(\\?_)|-)", body):
+        if not re.search(r"\br/anime\b(?!(\\?_)|-)", body, re.IGNORECASE):
             message.mark_read()
             continue
 


### PR DESCRIPTION
It currently does not match `r/Anime`: [example comment](https://www.reddit.com/r/animequestions/comments/1ln6cu7/whats_an_anime_thats_underrated_that_u_like_so/n0dqzny/).