### PR TITLE
back pending rabbitmq messages in postgres to allow for persistent retrying

### DIFF
--- a/src/data/base_data.py
+++ b/src/data/base_data.py
@@ -183,7 +183,8 @@ class BaseData:
         sql = text(f"""DELETE FROM {model.table}
             WHERE {model.pk_field} = :pk""")
 
-        return self.execute(sql, pk=getattr(model, model.pk_field))
+        with session_scope() as session:
+            return session.execute(sql, {"pk": getattr(model, model.pk_field)}).rowcount
 
     def execute(self, sql: Union[str, text], **kwargs):
         if isinstance(sql, str):

--- a/src/data/rabbitmq_pending_message_data.py
+++ b/src/data/rabbitmq_pending_message_data.py
@@ -13,12 +13,10 @@ class RabbitmqPendingMessageModel(BaseModel):
 
 class RabbitmqPendingMessageData(BaseData):
     def get_rabbitmq_pending_message_by_id(self, id: int) -> Optional[RabbitmqPendingMessageModel]:
-        sql = text(
-            """
+        sql = text("""
         SELECT * FROM rabbitmq_pending_messages
         WHERE id = :id;
-        """
-        )
+        """)
 
         result_rows = self.execute(sql, id=id)
         if not result_rows:
@@ -27,12 +25,10 @@ class RabbitmqPendingMessageData(BaseData):
         return RabbitmqPendingMessageModel(result_rows[0])
 
     def get_rabbitmq_pending_messages(self) -> list[RabbitmqPendingMessageModel]:
-        sql = text(
-            """
+        sql = text("""
             SELECT * FROM rabbitmq_pending_messages
             ORDER BY created_time ASC;
-            """
-        )
+            """)
 
         result_rows = self.execute(sql)
         return [RabbitmqPendingMessageModel(row) for row in result_rows]

--- a/src/data/rabbitmq_pending_message_data.py
+++ b/src/data/rabbitmq_pending_message_data.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from sqlalchemy.sql import text
+
+from data.base_data import BaseModel, BaseData
+
+
+class RabbitmqPendingMessageModel(BaseModel):
+    _table = "rabbitmq_pending_messages"
+    _pk_field = "id"
+    _columns = ["id", "type", "exchange_name", "queue_name", "json_body", "created_time"]
+
+
+class RabbitmqPendingMessageData(BaseData):
+    def get_rabbitmq_pending_message_by_id(self, id: int) -> Optional[RabbitmqPendingMessageModel]:
+        sql = text(
+            """
+        SELECT * FROM rabbitmq_pending_messages
+        WHERE id = :id;
+        """
+        )
+
+        result_rows = self.execute(sql, id=id)
+        if not result_rows:
+            return None
+
+        return RabbitmqPendingMessageModel(result_rows[0])
+
+    def get_rabbitmq_pending_messages(self) -> list[RabbitmqPendingMessageModel]:
+        sql = text(
+            """
+            SELECT * FROM rabbitmq_pending_messages
+            ORDER BY created_time ASC;
+            """
+        )
+
+        result_rows = self.execute(sql)
+        return [RabbitmqPendingMessageModel(row) for row in result_rows]

--- a/src/services/rabbitmq_pending_message_service.py
+++ b/src/services/rabbitmq_pending_message_service.py
@@ -1,0 +1,40 @@
+from typing import Optional
+
+from data.rabbitmq_pending_message_data import RabbitmqPendingMessageData, RabbitmqPendingMessageModel
+
+_rabbitmq_pending_message_data = RabbitmqPendingMessageData()
+
+
+def get_pending_message_by_id(id: int) -> Optional[RabbitmqPendingMessageModel]:
+    """
+    Gets a single rabbitmq_pending_message from the database.
+    """
+
+    return _rabbitmq_pending_message_data.get_rabbitmq_pending_message_by_id(id)
+
+
+def get_pending_messages() -> list[RabbitmqPendingMessageModel]:
+    """
+    Get all rabbitmq_pending_messages in the DB. Ordered by created_time ascending
+    """
+
+    return _rabbitmq_pending_message_data.get_rabbitmq_pending_messages()
+
+
+def insert_pending_message(
+    exchange_name: str, queue_name: str, json_body: str, type: str
+) -> RabbitmqPendingMessageModel:
+    """Adds a new pending rabbitmq message to the database."""
+
+    db_model = RabbitmqPendingMessageModel()
+    db_model.exchange_name = exchange_name
+    db_model.queue_name = queue_name
+    db_model.json_body = json_body
+    db_model.type = type
+
+    saved_db_model = _rabbitmq_pending_message_data.insert(db_model)
+    return saved_db_model
+
+
+def delete_pending_message(pending_message: RabbitmqPendingMessageModel):
+    return _rabbitmq_pending_message_data.delete(pending_message)

--- a/tools/db_migration/versions/20251220T022458Z_add_rabbitmq_pending_table_a5f2ff2c36f8.py
+++ b/tools/db_migration/versions/20251220T022458Z_add_rabbitmq_pending_table_a5f2ff2c36f8.py
@@ -1,0 +1,41 @@
+"""Add rabbitmq pending table
+
+Revision ID: a5f2ff2c36f8
+Revises: 03f4360f81fc
+Create Date: 2025-12-20 02:24:58.431032+00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a5f2ff2c36f8"
+down_revision = "03f4360f81fc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+    CREATE TABLE rabbitmq_pending_messages (
+        id BIGSERIAL PRIMARY KEY,
+        type TEXT NOT NULL,
+        exchange_name TEXT NOT NULL,
+        queue_name TEXT NOT NULL,
+        json_body JSONB NOT NULL,
+        created_time TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_rabbitmq_pending_messages_created_time ON rabbitmq_pending_messages(created_time);
+    """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+    DROP TABLE IF EXISTS rabbitmq_pending_messages;
+    """
+    )

--- a/tools/db_migration/versions/20251220T022458Z_add_rabbitmq_pending_table_a5f2ff2c36f8.py
+++ b/tools/db_migration/versions/20251220T022458Z_add_rabbitmq_pending_table_a5f2ff2c36f8.py
@@ -7,8 +7,6 @@ Create Date: 2025-12-20 02:24:58.431032+00:00
 """
 
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision = "a5f2ff2c36f8"
@@ -18,8 +16,7 @@ depends_on = None
 
 
 def upgrade():
-    op.execute(
-        """
+    op.execute("""
     CREATE TABLE rabbitmq_pending_messages (
         id BIGSERIAL PRIMARY KEY,
         type TEXT NOT NULL,
@@ -28,14 +25,12 @@ def upgrade():
         json_body JSONB NOT NULL,
         created_time TIMESTAMPTZ NOT NULL DEFAULT now()
     );
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_rabbitmq_pending_messages_created_time ON rabbitmq_pending_messages(created_time);
-    """
-    )
+    CREATE UNIQUE INDEX IF NOT EXISTS
+        idx_rabbitmq_pending_messages_created_time ON rabbitmq_pending_messages(created_time);
+    """)
 
 
 def downgrade():
-    op.execute(
-        """
+    op.execute("""
     DROP TABLE IF EXISTS rabbitmq_pending_messages;
-    """
-    )
+    """)


### PR DESCRIPTION
The core issue with this, is that before, if rabbitmq went down, and then you restarted the modbot feeds container, then it would simply drop any messages it didn't get to sent to rabbitmq.

Now it will store them in postgres instead of memory.

I'm not 100% satisfied with this implementation. It's still pretty fundamentally dependent on using exceptions to blow up, and reconnect to everything as it's recovery method. This means that it'll continue to stop processing db stuff while rabbitmq is down. Which means that if it's down for too long, data will be pushed out of the feed and won't get added to the db at all. Which I don't like.

Tbh, part of me is wondering why I even went for RabbitMQ instead of message queuing through Postgres. But that's already done and this really doesn't need to be so robust.

I think the ideal implementation has RabbitMQ fully facaded and we like keep track of if we know it's up or down. And when we know it's down, we like retry the pending messages before sending off any new messages (so that order is maintained). Tbh, order should not be precisely guaranteed when processing messages, so tbh, even like flushing any pending messages after a success (resulting in 1 potentially very out of order message) I think is as robust as is reasonable.

Idk if I'll actually do that though. I probably shouldn't. We should just not let the rabbitmq container go down for extended periods of time.